### PR TITLE
Fix modal opening bug and refresh landing design

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta property="og:title" content="Prouti — Nutrición simple, progreso real">
   <meta property="og:description" content="Prouti: Calcula tus macros, registra lo que comes y mide tu avance.">
   <meta property="og:image" content="/og-image.png">
-  <meta property="og:url" content="https://example.com">
+  <meta property="og:url" content="https://calculadora-edumvt.vercel.app">
   <link rel="icon" href="/favicon.ico">
   <link rel="stylesheet" href="/styles.css">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700;800&family=Rubik+Rounded:wght@400;500&display=swap" rel="stylesheet">

--- a/styles.css
+++ b/styles.css
@@ -7,10 +7,23 @@
 *{box-sizing:border-box;}
 html,body{margin:0;padding:0;}
 body{
+  position:relative;
   font-family:'Poppins','Rubik Rounded',system-ui,-apple-system,sans-serif;
-  background:var(--paper);
   color:var(--ink);
   min-height:100vh;
+  background:linear-gradient(180deg,#f7fffb 0%,#eefaf4 100%);
+}
+body::before{
+  content:'';
+  position:fixed; inset:0; z-index:-1;
+  pointer-events:none;
+  opacity:.035;
+  background:
+    radial-gradient(1200px 600px at 10% -10%, rgba(16,185,129,.10), transparent 60%),
+    radial-gradient(1000px 500px at 110% 0%, rgba(16,185,129,.06), transparent 60%),
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='90' height='90' viewBox='0 0 90 90'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/><feComponentTransfer><feFuncA type='table' tableValues='0 0 .06 0'/></feComponentTransfer></filter><rect width='100%' height='100%' filter='url(%23n)' /></svg>");
+  background-size:auto, auto, 300px 300px;
+  mix-blend-mode:multiply;
 }
 
 .hero{
@@ -19,7 +32,6 @@ body{
   justify-content:center;
   min-height:100vh;
   text-align:center;
-  background:linear-gradient(135deg,#d8fff1,#f7fffb);
   padding:20px;
 }
 .hero-content{max-width:600px;}
@@ -28,10 +40,11 @@ body{
 .lead{margin:16px 0 0; font-size:clamp(1rem,2vw,1.25rem);}
 
 .card{
-  background:rgba(255,255,255,0.7);
-  backdrop-filter:blur(8px);
+  backdrop-filter:blur(10px);
+  background:rgba(255,255,255,.75);
+  border:1px solid rgba(12,130,94,.14);
   border-radius:16px;
-  box-shadow:0 10px 30px rgba(0,0,0,0.08);
+  box-shadow:0 18px 48px rgba(5,28,22,.10);
   padding:24px;
 }
 .access-card{margin-top:32px;}
@@ -56,7 +69,10 @@ body{
 .btn-primary{
   background:var(--emerald);
   color:#fff;
+  box-shadow:0 2px 4px rgba(16,185,129,.3);
 }
+.btn-primary:hover{box-shadow:0 4px 8px rgba(16,185,129,.35);}
+.btn-primary:active{box-shadow:0 1px 2px rgba(16,185,129,.2);}
 .btn-soft{
   background:#fff;
   color:var(--emerald);
@@ -78,7 +94,7 @@ body{
   inset:0;
   display:grid;
   place-items:center;
-  background:rgba(0,0,0,0.4);
+  background:rgba(0,0,0,0.5);
   animation:fade .2s ease;
 }
 .modal-card{


### PR DESCRIPTION
## Summary
- prevent login/signup modals from auto-opening and add ESC/backdrop dismissal
- add subtle gradient and noise texture background with glassy access card and refined buttons

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c114f6e0d48326b1d938a347d9ab14