### PR TITLE
Fix modal initialization and polish landing UI

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,57 +6,29 @@ const setText = (id,v)=>{ const el=$(id); if(el) el.textContent = String(v ?? ''
 const todayStr = ()=> new Date().toISOString().slice(0,10);
 
 function openModal(id){
-  const el = $(id); if(!el) return;
-  el.classList.remove('hide');
-  document.body.style.overflow = 'hidden';
-  const first = el.querySelector('input, button, [tabindex]:not([tabindex="-1"])');
-  if(first) setTimeout(()=> first.focus(), 0);
+  const el=$(id); if(!el) return; el.classList.remove('hide'); document.body.style.overflow='hidden';
+  const first = el.querySelector('input,button,[tabindex]:not([tabindex="-1"])'); if(first) setTimeout(()=>first.focus(),0);
 }
 function closeModal(id){
-  const el = $(id); if(!el) return;
-  el.classList.add('hide');
-  document.body.style.overflow = '';
+  const el=$(id); if(!el) return; el.classList.add('hide'); document.body.style.overflow='';
 }
-
-function wireModalDismiss(){
-  document.addEventListener('keydown', (e)=>{
-    if(e.key === 'Escape'){
-      ['loginModal','signupModal'].forEach(m => {
-        const el = $(m);
-        if(el && !el.classList.contains('hide')) closeModal(m);
-      });
-    }
-  });
-  ['loginModal','signupModal'].forEach(m=>{
-    const el=$(m);
-    if(!el) return;
-    el.addEventListener('click', (e)=>{
-      if(e.target.closest('.modal-card')) return;
-      closeModal(m);
-    });
-  });
-}
-
 function wireAuthButtons(){
-  const L=$('btnOpenLogin'), S=$('btnOpenSignup');
-  if(L) L.onclick = ()=> openModal('loginModal');
-  if(S) S.onclick = ()=> openModal('signupModal');
-
-  const CL=$('btnCloseLogin'), CS=$('btnCloseSignup');
-  if(CL) CL.onclick = ()=> closeModal('loginModal');
-  if(CS) CS.onclick = ()=> closeModal('signupModal');
+  $('btnOpenLogin')?.addEventListener('click', ()=>openModal('loginModal'));
+  $('btnOpenSignup')?.addEventListener('click',()=>openModal('signupModal'));
+  $('btnCloseLogin')?.addEventListener('click', ()=>closeModal('loginModal'));
+  $('btnCloseSignup')?.addEventListener('click',()=>closeModal('signupModal'));
 }
-
-function maybeOpenModalFromQuery(){
-  const q = new URLSearchParams(location.search);
-  const m = q.get('modal');
-  if(m === 'login') openModal('loginModal');
-  if(m === 'signup') openModal('signupModal');
+function wireModalDismiss(){
+  document.addEventListener('keydown',e=>{ if(e.key==='Escape'){ ['loginModal','signupModal'].forEach(id=>{ const el=$(id); if(el && !el.classList.contains('hide')) closeModal(id); }) } });
+  ['loginModal','signupModal'].forEach(id=>{
+    const el=$(id); el?.addEventListener('click', e=>{ if(!e.target.closest('.modal-card')) closeModal(id); });
+  });
 }
-
-wireAuthButtons();
-wireModalDismiss();
-maybeOpenModalFromQuery();
+wireAuthButtons(); wireModalDismiss();
+const q = new URLSearchParams(location.search);
+const m = q.get('modal'); // 'login' | 'signup'
+if(m==='login')  openModal('loginModal');
+if(m==='signup') openModal('signupModal');
 
 // Supabase client
 const { createClient } = supabase;

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
 
   <!-- Login Modal -->
   <div id="loginModal" class="modal hide" role="dialog" aria-modal="true" aria-labelledby="loginTitle">
+    <div class="modal-backdrop"></div>
     <div class="modal-card card">
       <h2 id="loginTitle">Iniciar sesión</h2>
       <div class="stack-12">
@@ -58,6 +59,7 @@
 
   <!-- Signup Modal -->
   <div id="signupModal" class="modal hide" role="dialog" aria-modal="true" aria-labelledby="signupTitle">
+    <div class="modal-backdrop"></div>
     <div class="modal-card card">
       <h2 id="signupTitle">Crear cuenta</h2>
       <div class="stack-12">

--- a/styles.css
+++ b/styles.css
@@ -21,8 +21,8 @@ body::before{
   background:
     radial-gradient(1200px 600px at 10% -10%, rgba(16,185,129,.10), transparent 60%),
     radial-gradient(1000px 500px at 110% 0%, rgba(16,185,129,.06), transparent 60%),
-    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='90' height='90' viewBox='0 0 90 90'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/><feComponentTransfer><feFuncA type='table' tableValues='0 0 .06 0'/></feComponentTransfer></filter><rect width='100%' height='100%' filter='url(%23n)' /></svg>");
-  background-size:auto, auto, 300px 300px;
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='110' height='110' viewBox='0 0 110 110'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix type='saturate' values='0'/><feComponentTransfer><feFuncA type='table' tableValues='0 0 .05 0'/></feComponentTransfer></filter><rect width='100%' height='100%' filter='url(%23n)' /></svg>");
+  background-size:auto, auto, 360px 360px;
   mix-blend-mode:multiply;
 }
 
@@ -87,20 +87,29 @@ body::before{
 .center{text-align:center;}
 .muted{color:#40675e; font-size:0.875rem;}
 
-.hide{display:none;}
+.hide{display:none !important;}
 
 .modal{
   position:fixed;
   inset:0;
   display:grid;
   place-items:center;
-  background:rgba(0,0,0,0.5);
+  z-index:60;
+}
+.modal-backdrop{
+  position:fixed;
+  inset:0;
+  background:rgba(8,20,16,.55);
   animation:fade .2s ease;
+  z-index:0;
 }
 .modal-card{
-  width:90%;
-  max-width:460px;
+  max-width:520px;
+  width:100%;
+  border-radius:20px;
   animation:scale .2s ease;
+  position:relative;
+  z-index:1;
 }
 
 @keyframes fade{from{opacity:0;} to{opacity:1;}}


### PR DESCRIPTION
## Summary
- ensure auth modals start hidden and open only via user action or query param
- add subtle textured background and glassy card visuals
- refactor modal JS helpers and wiring per spec

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1177fceac8326a164c35afd0622cd