### PR TITLE
Rediseño del hub en SPA con secciones Metas, Comidas y Progreso

### DIFF
--- a/app.html
+++ b/app.html
@@ -10,81 +10,84 @@
 </head>
 <body>
   <header class="topbar" role="banner">
-    <div class="brand">Prouti</div>
+    <a id="navToHub" class="brand" href="#hub">Prouti</a>
     <nav class="menu" aria-label="Navegación principal">
-      <a class="chip" href="#goals">Calcula tus macros</a>
-      <a class="chip" href="#meals">Registra tus comidas</a>
-      <a class="chip" href="#progress">Mide tu avance</a>
+      <button id="navToGoals" class="chip" type="button">Metas</button>
+      <button id="navToMeals" class="chip" type="button">Comidas</button>
+      <button id="navToProgress" class="chip" type="button">Progreso</button>
     </nav>
     <div class="user-menu">
-      <span id="userEmail" class="chip" aria-live="polite"></span>
       <button id="btnLogout" class="chip" type="button">Cerrar sesión</button>
     </div>
   </header>
 
-  <main class="wrap">
-    <section id="summary" aria-labelledby="hSummary">
-      <h2 id="hSummary">Resumen de hoy</h2>
-      <div id="summaryCards" class="grid stats">
-        <article class="stat-card skeleton">
-          <p class="stat-label">Calorías</p>
-          <p class="stat-value"><span id="sumKcal">0</span> / <span id="goalKcal">0</span> kcal</p>
+  <main>
+    <section id="hub" class="section">
+      <div class="hub-grid">
+        <article class="hub-card card">
+          <h2>Calcula tus macros</h2>
+          <p id="statGoals" class="quick-stat skeleton">…</p>
+          <button id="ctaGoGoals" class="btn btn-primary" type="button">Ir a metas</button>
         </article>
-        <article class="stat-card skeleton">
-          <p class="stat-label">Proteína</p>
-          <p class="stat-value"><span id="sumProt">0</span> / <span id="goalProt">0</span> g</p>
+        <article class="hub-card card">
+          <h2>Registra tus comidas</h2>
+          <p id="statMeals" class="quick-stat skeleton">…</p>
+          <button id="ctaGoMeals" class="btn btn-primary" type="button">Ir a comidas</button>
         </article>
-        <article class="stat-card skeleton">
-          <p class="stat-label">Carbos</p>
-          <p class="stat-value"><span id="sumCarb">0</span> / <span id="goalCarb">0</span> g</p>
-        </article>
-        <article class="stat-card skeleton">
-          <p class="stat-label">Grasas</p>
-          <p class="stat-value"><span id="sumFat">0</span> / <span id="goalFat">0</span> g</p>
+        <article class="hub-card card">
+          <h2>Mide tu avance</h2>
+          <p id="statProgress" class="quick-stat skeleton">…</p>
+          <button id="ctaGoProgress" class="btn btn-primary" type="button">Ver progreso</button>
         </article>
       </div>
-      <p id="summaryTime" class="muted" aria-live="polite"></p>
     </section>
 
-    <section id="goals" aria-labelledby="hGoals">
+    <section id="goals" class="section hide" aria-labelledby="hGoals">
       <h2 id="hGoals">Metas</h2>
       <div class="card">
-        <form id="formGoals" class="grid goal-grid" autocomplete="off">
+        <form class="grid" autocomplete="off">
           <div>
-            <label for="metaKcal">Calorías objetivo</label>
-            <input id="metaKcal" type="number" inputmode="numeric" min="0" placeholder="2000" />
+            <label for="metaKcal">Calorías (kcal)</label>
+            <input id="metaKcal" type="number" inputmode="numeric" min="0" />
           </div>
           <div>
             <label for="metaProt">Proteína (g)</label>
-            <input id="metaProt" type="number" inputmode="numeric" min="0" placeholder="150" />
+            <input id="metaProt" type="number" inputmode="numeric" min="0" />
           </div>
           <div>
             <label for="metaCarb">Carbos (g)</label>
-            <input id="metaCarb" type="number" inputmode="numeric" min="0" placeholder="200" />
+            <input id="metaCarb" type="number" inputmode="numeric" min="0" />
           </div>
           <div>
-            <label for="metaGrasa">Grasas (g)</label>
-            <input id="metaGrasa" type="number" inputmode="numeric" min="0" placeholder="70" />
+            <label for="metaFat">Grasas (g)</label>
+            <input id="metaFat" type="number" inputmode="numeric" min="0" />
           </div>
           <div class="actions">
             <button id="btnSaveGoals" class="btn btn-primary" type="button">Guardar metas</button>
           </div>
         </form>
-        <p id="goalMsg" class="muted" role="status" aria-live="polite"></p>
+        <p id="msgGoals" class="muted" aria-live="polite"></p>
       </div>
     </section>
 
-    <section id="meals" aria-labelledby="hMeals">
+    <section id="meals" class="section hide" aria-labelledby="hMeals">
       <h2 id="hMeals">Comidas</h2>
+      <div id="todaySummary" class="card">
+        <div class="progress-row skeleton"><span>Calorías</span><div class="bar"><div class="fill" style="width:0%"></div></div><span>0/0</span></div>
+      </div>
       <div class="card">
-        <form id="formMeal" class="grid meal-grid" autocomplete="off">
+        <form class="grid meal-grid" autocomplete="off">
           <div class="wide">
             <label for="mealName">Nombre</label>
-            <input id="mealName" type="text" placeholder="Pechuga de pollo" autocomplete="off" />
+            <input id="mealName" type="text" autocomplete="off" />
           </div>
           <div>
             <label for="mealQty">Cantidad (g)</label>
             <input id="mealQty" type="number" step="1" min="0" value="100" />
+          </div>
+          <div>
+            <label for="mealKcal">Calorías</label>
+            <input id="mealKcal" type="number" step="1" min="0" />
           </div>
           <div>
             <label for="mealProt">Proteína (g)</label>
@@ -98,32 +101,29 @@
             <label for="mealFat">Grasas (g)</label>
             <input id="mealFat" type="number" step="0.1" min="0" />
           </div>
-          <div>
-            <label for="mealKcal">o Calorías</label>
-            <input id="mealKcal" type="number" step="1" min="0" />
-          </div>
           <div class="actions">
             <button id="btnAddMeal" class="btn btn-primary" type="button">Agregar</button>
           </div>
         </form>
-        <p id="mealMsg" class="muted" role="status" aria-live="polite"></p>
+        <p id="msgMeals" class="muted" aria-live="polite"></p>
       </div>
       <div class="card table-card">
         <table class="table" aria-label="Comidas de hoy">
           <thead>
-            <tr><th>Hora</th><th>Comida</th><th>Kcal</th><th>P</th><th>C</th><th>G</th><th></th></tr>
+            <tr><th>Comida</th><th>Kcal</th><th>P</th><th>C</th><th>G</th><th></th></tr>
           </thead>
-          <tbody id="mealTable"></tbody>
+          <tbody id="mealsTbody"></tbody>
         </table>
         <button id="btnMoreMeals" class="btn btn-soft hide" type="button">Ver más</button>
       </div>
     </section>
 
-    <section id="progress" aria-labelledby="hProgress">
+    <section id="progress" class="section hide" aria-labelledby="hProgress">
       <h2 id="hProgress">Progreso</h2>
       <div class="card">
-        <div id="progressChart" class="progress-chart" aria-label="Gráfica de progreso"></div>
-        <p id="progressMsg" class="muted">Registra tus comidas para ver tu progreso.</p>
+        <div id="kpiCompliance" class="kpi skeleton">0%</div>
+        <div id="chartArea" class="chart-area"></div>
+        <p id="msgProgress" class="muted" aria-live="polite"></p>
       </div>
     </section>
   </main>

--- a/app.js
+++ b/app.js
@@ -1,77 +1,85 @@
-// Utilidades básicas
+// Utilidades y helpers
 const $ = id => document.getElementById(id);
-const qs = sel => document.querySelector(sel);
-const todayStr = () => new Date().toISOString().slice(0,10);
-
-const { createClient } = supabase;
-const SUPABASE_URL = "https://nzzzeycpfdtvzphbupbf.supabase.co";
-const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im56enpleWNwZmR0dnpwaGJ1cGJmIiwi cm9sZSI6ImFub24iLCJpYXQiOjE3NTc0NDA3MTIsImV4cCI6MjA3MzAxNjcxMn0.HoAjTwnWdtjueVALlX4-du7uF919QEMj8SS2CHP0N44";
-const sb = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-
-const formatKcal = n => `${Math.round(n)} kcal`;
-const formatGrams = n => `${Math.round(n)} g`;
-function relTime(ts){
-  const diff = Math.floor((Date.now()-ts)/1000);
-  if(diff < 60) return `hace ${diff}s`;
-  if(diff < 3600) return `hace ${Math.floor(diff/60)}m`;
-  if(diff < 86400) return `hace ${Math.floor(diff/3600)}h`;
-  return `hace ${Math.floor(diff/86400)}d`;
-}
-
-function renderEmptyState(container,title,ctaText,onClick){
-  container.innerHTML = '';
-  const div=document.createElement('div');
-  div.className='center';
-  const p=document.createElement('p');p.textContent=title;p.className='muted';div.appendChild(p);
-  const btn=document.createElement('button');btn.type='button';btn.textContent=ctaText;btn.className='btn btn-primary';btn.addEventListener('click',onClick);div.appendChild(btn);
-  container.appendChild(div);
-}
-
-async function loadToday(){
-  const cards = $('#summaryCards');
-  cards.querySelectorAll('.stat-card').forEach(c=>c.classList.add('skeleton'));
-  const { data:{ user } } = await sb.auth.getUser();
-  if(!user){ location.href='/'; return; }
-  const [{ data:goal }, { data:totals }] = await Promise.all([
-    sb.from('goals').select('*').eq('user_id', user.id).maybeSingle(),
-    sb.from('v_daily_totals').select('*').eq('user_id', user.id).eq('day', todayStr()).maybeSingle()
-  ]);
-  $('#goalKcal').textContent = goal?.kcal_target || 0;
-  $('#goalProt').textContent = goal?.protein_g_target || 0;
-  $('#goalCarb').textContent = goal?.carbs_g_target || 0;
-  $('#goalFat').textContent = goal?.fat_g_target || 0;
-  $('#sumKcal').textContent = Math.round(totals?.kcal || 0);
-  $('#sumProt').textContent = Math.round(totals?.protein_g || 0);
-  $('#sumCarb').textContent = Math.round(totals?.carbs_g || 0);
-  $('#sumFat').textContent = Math.round(totals?.fat_g || 0);
-  cards.querySelectorAll('.stat-card').forEach(c=>c.classList.remove('skeleton'));
-  $('#summaryTime').textContent = 'Actualizado ' + relTime(Date.now());
-  if(!goal){
-    renderEmptyState(cards,'Configura tus metas','Configura tus metas',()=>location.hash='#goals');
+const el = (sel, root=document) => root.querySelector(sel);
+const fmt = {
+  kcal: n => `${(n||0).toFixed(0)} kcal`,
+  g: n => `${(n||0).toFixed(0)} g`,
+  pct: n => `${Math.round(n||0)}%`
+};
+function setLive(id, msg){
+  const m = $(id);
+  if(m){
+    m.textContent = msg;
+    m.setAttribute('role','status');
+    m.setAttribute('aria-live','polite');
   }
 }
+const todayStr = () => new Date().toISOString().slice(0,10);
 
+// Supabase
+const { createClient } = supabase;
+const SUPABASE_URL = "https://nzzzeycpfdtvzphbupbf.supabase.co";
+const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im56enpleWNwZmR0dnpwaGJ1cGJmIiwi\ncm9sZSI6ImFub24iLCJpYXQiOjE3NTc0NDA3MTIsImV4cCI6MjA3MzAxNjcxMn0.HoAjTwnWdtjueVALlX4-du7uF919QEMj8SS2CHP0N44";
+const sb = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+// SPA helpers
+const sections = ['hub','goals','meals','progress'];
+function show(id){ sections.forEach(s => $(s).classList.toggle('hide', s!==id)); }
+
+let user=null;
+let goals=null;
+let mealPage=0;
+
+// Eventos de navegación
+$('#navToHub').onclick = () => show('hub');
+$('#navToGoals').onclick = $('#ctaGoGoals').onclick = () => show('goals');
+$('#navToMeals').onclick = $('#ctaGoMeals').onclick = () => show('meals');
+$('#navToProgress').onclick = $('#ctaGoProgress').onclick = () => show('progress');
+$('#btnLogout').onclick = async()=>{ await sb.auth.signOut(); location.href='/'; };
+$('#btnSaveGoals').onclick = saveGoals;
+$('#btnAddMeal').onclick = addMeal;
+$('#mealsTbody').addEventListener('click',e=>{
+  const btn = e.target.closest('.btnDelMeal');
+  if(btn) deleteMeal(btn.dataset.id);
+});
+$('#btnMoreMeals').onclick = ()=>{ mealPage++; loadMealsToday(false); };
+
+// Carga inicial y guard de auth
+document.addEventListener('DOMContentLoaded', async()=>{
+  const { data:{ session } } = await sb.auth.getSession();
+  if(!session){ location.href='/'; return; }
+  user = session.user;
+  await loadGoals();
+  await loadMealsToday();
+  await loadCompliance7d();
+  show('hub');
+});
+
+// Funciones de datos
 async function loadGoals(){
-  const { data:{ user } } = await sb.auth.getUser();
-  if(!user) return;
   const { data } = await sb.from('goals').select('*').eq('user_id', user.id).maybeSingle();
+  goals = data;
   if(data){
     $('#metaKcal').value = data.kcal_target || '';
     $('#metaProt').value = data.protein_g_target || '';
     $('#metaCarb').value = data.carbs_g_target || '';
-    $('#metaGrasa').value = data.fat_g_target || '';
+    $('#metaFat').value = data.fat_g_target || '';
+    $('#statGoals').textContent = `${fmt.kcal(data.kcal_target)} / ${fmt.g(data.protein_g_target)}`;
+  }else{
+    $('#statGoals').textContent = 'Sin metas';
   }
+  $('#statGoals').classList.remove('skeleton');
 }
 
 async function saveGoals(){
-  const msg = $('#goalMsg'); msg.textContent='';
   const kcal = Number($('#metaKcal').value);
   const prot = Number($('#metaProt').value);
   const carb = Number($('#metaCarb').value);
-  const fat = Number($('#metaGrasa').value);
-  if(kcal<=0){ msg.textContent='Ingresa valores válidos.'; return; }
-  const { data:{ user } } = await sb.auth.getUser();
-  if(!user){ location.href='/'; return; }
+  const fat = Number($('#metaFat').value);
+  if([kcal,prot,carb,fat].some(v=>isNaN(v)||v<=0)){
+    setLive('msgGoals','Ingresa valores válidos');
+    return;
+  }
   const { error } = await sb.from('goals').upsert({
     user_id:user.id,
     kcal_target:kcal,
@@ -79,47 +87,67 @@ async function saveGoals(){
     carbs_g_target:carb,
     fat_g_target:fat
   });
-  msg.textContent = error ? ('Error: '+error.message) : 'Metas guardadas';
-  await loadToday();
+  setLive('msgGoals', error?('Error: '+error.message):'Metas guardadas');
+  await loadGoals();
+  await loadMealsToday();
+  await loadCompliance7d();
 }
 
-let mealPage = 0;
 async function loadMealsToday(reset=true){
-  const body = $('#mealTable');
+  const body = $('#mealsTbody');
   if(reset){ body.innerHTML=''; mealPage=0; }
-  const { data:{ user } } = await sb.auth.getUser();
-  if(!user) return;
   const { data, error, count } = await sb.from('meals')
-    .select('id,eaten_at,food_name,kcal,protein_g,carbs_g,fat_g',{ count:'exact' })
+    .select('id,food_name,kcal,protein_g,carbs_g,fat_g',{ count:'exact' })
     .eq('user_id', user.id).eq('eaten_at', todayStr())
     .order('id',{ascending:false})
     .range(mealPage*10, mealPage*10+9);
-  if(error){ body.innerHTML=`<tr><td colspan="7" class="muted">Error: ${error.message}</td></tr>`; return; }
+  if(error){ body.innerHTML=`<tr><td colspan="6" class="muted">Error</td></tr>`; return; }
   if(reset && (!data || data.length===0)){
-    body.innerHTML=`<tr><td colspan="7" class="muted">Aún no registras comidas hoy.</td></tr>`;
-    $('#btnMoreMeals').classList.add('hide');
-    return;
+    body.innerHTML=`<tr><td colspan="6" class="muted">Aún no hay comidas</td></tr>`;
+  }else{
+    data.forEach(m=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${m.food_name}</td><td>${Math.round(m.kcal)}</td><td>${Math.round(m.protein_g)}</td><td>${Math.round(m.carbs_g)}</td><td>${Math.round(m.fat_g)}</td><td><button type="button" class="chip btnDelMeal" data-id="${m.id}">✕</button></td>`;
+      body.appendChild(tr);
+    });
   }
-  data.forEach(m=>{
-    const tr=document.createElement('tr');
-    tr.innerHTML=`<td>--:--</td><td>${m.food_name}</td><td>${Math.round(m.kcal)}</td><td>${Math.round(m.protein_g)}</td><td>${Math.round(m.carbs_g)}</td><td>${Math.round(m.fat_g)}</td><td><button class="chip" data-id="${m.id}">✕</button></td>`;
-    body.appendChild(tr);
+  if((mealPage+1)*10 < (count||0)) $('#btnMoreMeals').classList.remove('hide'); else $('#btnMoreMeals').classList.add('hide');
+
+  const { data:totals } = await sb.from('v_daily_totals').select('*').eq('user_id', user.id).eq('day', todayStr()).maybeSingle();
+  renderTodaySummary(totals);
+  $('#statMeals').textContent = `${count||0} regs / ${fmt.kcal(totals?.kcal)}`;
+  $('#statMeals').classList.remove('skeleton');
+}
+
+function renderTodaySummary(totals){
+  const summary = $('#todaySummary');
+  summary.innerHTML='';
+  const t = totals || {};
+  const g = goals || {};
+  const list = [
+    {label:'Calorías', total:t.kcal, goal:g.kcal_target, fmt:fmt.kcal},
+    {label:'Proteína', total:t.protein_g, goal:g.protein_g_target, fmt:fmt.g},
+    {label:'Carbos', total:t.carbs_g, goal:g.carbs_g_target, fmt:fmt.g},
+    {label:'Grasas', total:t.fat_g, goal:g.fat_g_target, fmt:fmt.g}
+  ];
+  list.forEach(item=>{
+    const pct = item.goal ? Math.min(100,(item.total||0)/item.goal*100) : 0;
+    const row=document.createElement('div');
+    row.className='progress-row';
+    row.innerHTML=`<span>${item.label}</span><div class="bar"><div class="fill" style="width:${pct}%"></div></div><span>${item.fmt(item.total)} / ${item.fmt(item.goal)}</span>`;
+    summary.appendChild(row);
   });
-  const more=$('#btnMoreMeals');
-  if((mealPage+1)*10 < (count||0)) more.classList.remove('hide'); else more.classList.add('hide');
+  summary.classList.remove('skeleton');
 }
 
 async function addMeal(){
-  const msg = $('#mealMsg'); msg.textContent='';
-  const name = $('#mealName').value.trim();
-  const qty = Number($('#mealQty').value||0);
-  const prot = Number($('#mealProt').value||0);
-  const carb = Number($('#mealCarb').value||0);
-  const fat = Number($('#mealFat').value||0);
-  const kcalInput = Number($('#mealKcal').value||0);
-  if(!name || qty<=0){ msg.textContent='Datos inválidos'; return; }
-  const { data:{ user } } = await sb.auth.getUser();
-  if(!user){ location.href='/'; return; }
+  const name=$('#mealName').value.trim();
+  const qty=Number($('#mealQty').value);
+  const prot=Number($('#mealProt').value);
+  const carb=Number($('#mealCarb').value);
+  const fat=Number($('#mealFat').value);
+  const kcalInput=Number($('#mealKcal').value);
+  if(!name || qty<=0){ setLive('msgMeals','Datos inválidos'); return; }
   const kcal = kcalInput>0 ? kcalInput : prot*4 + carb*4 + fat*9;
   const { error } = await sb.from('meals').insert({
     user_id:user.id,
@@ -131,37 +159,49 @@ async function addMeal(){
     fat_g:fat,
     kcal
   });
-  msg.textContent = error ? ('Error: '+error.message) : 'Agregado';
+  setLive('msgMeals', error?('Error: '+error.message):'Agregado');
   if(!error){
     ['mealName','mealQty','mealProt','mealCarb','mealFat','mealKcal'].forEach(id=>{$(id).value='';});
     $('#mealQty').value='100';
-    loadMealsToday();
-    loadToday();
+    await loadMealsToday();
+    await loadCompliance7d();
   }
 }
 
 async function deleteMeal(id){
-  if(!id) return;
   if(!confirm('¿Eliminar comida?')) return;
   await sb.from('meals').delete().eq('id', id);
-  loadMealsToday();
-  loadToday();
+  await loadMealsToday();
+  await loadCompliance7d();
 }
 
-$('#mealTable').addEventListener('click',e=>{
-  const btn=e.target.closest('button[data-id]');
-  if(btn) deleteMeal(btn.dataset.id);
-});
-$('#btnMoreMeals').addEventListener('click',()=>{mealPage++;loadMealsToday(false);});
-$('#btnSaveGoals').addEventListener('click',saveGoals);
-$('#btnAddMeal').addEventListener('click',addMeal);
-$('#btnLogout').addEventListener('click',async()=>{await sb.auth.signOut();location.href='/';});
+async function loadCompliance7d(){
+  const fromDate = new Date();
+  fromDate.setDate(fromDate.getDate()-6);
+  const start = fromDate.toISOString().slice(0,10);
+  const { data } = await sb.from('v_daily_totals').select('day,kcal').eq('user_id', user.id).gte('day', start).lte('day', todayStr()).order('day');
+  const gkcal = goals?.kcal_target;
+  const points=[];
+  if(gkcal && data){
+    data.forEach(d=>{ points.push({day:d.day,pct:(d.kcal/gkcal*100)}); });
+  }
+  const avg = points.length ? points.reduce((a,b)=>a+b.pct,0)/points.length : 0;
+  $('#kpiCompliance').textContent = fmt.pct(avg);
+  $('#statProgress').textContent = points.length ? fmt.pct(avg) : 'Sin datos';
+  renderChart(points);
+  $('#kpiCompliance').classList.remove('skeleton');
+  $('#statProgress').classList.remove('skeleton');
+  setLive('msgProgress', points.length ? '' : 'Registra tus comidas para ver tu progreso.');
+}
 
-document.addEventListener('DOMContentLoaded',async()=>{
-  const { data:{ session } } = await sb.auth.getSession();
-  if(!session){ location.href='/'; return; }
-  $('#userEmail').textContent = session.user.email;
-  await loadToday();
-  await loadGoals();
-  await loadMealsToday();
-});
+function renderChart(points){
+  const area = $('#chartArea');
+  area.innerHTML='';
+  if(!points.length) return;
+  points.forEach(p=>{
+    const bar=document.createElement('div');
+    bar.className='chart-bar';
+    bar.style.height = `${Math.min(100,p.pct)}%`;
+    area.appendChild(bar);
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,10 @@
 :root{
   --emerald:#10b981;
-  --paper:#f8fffb;
   --ink:#0b1a20;
+  --paper:#f8fffb;
+  --soft:#ecfdf5;
+  --line:rgba(16,185,129,.18);
+  --shadow:0 20px 50px rgba(5,28,22,.10);
 }
 
 *{box-sizing:border-box;}
@@ -173,5 +176,19 @@ body::before{
 @keyframes skeleton{0%{transform:translateX(-100%);}100%{transform:translateX(100%);}}
 
 .progress-chart{height:200px;background:rgba(255,255,255,.5);border-radius:12px;}
+
+.section{max-width:1100px;margin:0 auto;padding:32px 20px;}
+
+.hub-grid{display:grid;gap:24px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));}
+.hub-card{text-align:center;display:flex;flex-direction:column;gap:12px;}
+.quick-stat{margin:0;color:#25574b;font-size:0.9rem;}
+
+.progress-row{display:grid;grid-template-columns:80px 1fr auto;align-items:center;gap:8px;margin-bottom:8px;}
+.bar{background:var(--soft);height:8px;border-radius:999px;overflow:hidden;}
+.bar .fill{background:var(--emerald);height:100%;}
+
+.kpi{font-size:2rem;font-weight:700;text-align:center;margin-bottom:16px;}
+.chart-area{display:flex;align-items:flex-end;gap:8px;height:160px;background:rgba(255,255,255,.5);border-radius:12px;padding:8px;}
+.chart-bar{flex:1;background:var(--soft);border-radius:4px 4px 0 0;}
 
 .hide{display:none!important;}


### PR DESCRIPTION
## Resumen
- Reestructura app.html como SPA ligera con hub inicial y navegación interna a Metas, Comidas y Progreso.
- Ajusta estilos globales añadiendo variables, grid responsivo para el hub y barras de progreso y gráficas simples.
- Implementa en app.js el guard de autenticación, router de secciones y lógica para metas, comidas, progreso y estadísticas rápidas.

## Pruebas
- `node --version`
- `node --check app.js`
- `npm test` *(falla: no hay package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68c12479ea7c8326b4266e72d33be516