### PR TITLE
feat: implement Supabase auth modals and UI polish

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -67,20 +67,21 @@ body::before{
   outline:3px solid var(--emerald);
   outline-offset:2px;
 }
-.btn:hover{filter:brightness(1.05);}
+.btn:hover{filter:brightness(1.05);box-shadow:0 4px 8px rgba(0,0,0,.08);}
 .btn:active{transform:translateY(1px);}
 .btn-primary{
   background:var(--emerald);
   color:#fff;
   box-shadow:0 2px 4px rgba(16,185,129,.3);
 }
-.btn-primary:hover{box-shadow:0 4px 8px rgba(16,185,129,.35);}
+.btn-primary:hover{box-shadow:0 4px 12px rgba(16,185,129,.35);}
 .btn-primary:active{box-shadow:0 1px 2px rgba(16,185,129,.2);}
 .btn-soft{
   background:#fff;
   color:var(--emerald);
   border-color:var(--emerald);
 }
+.btn-soft:hover{box-shadow:0 4px 8px rgba(16,185,129,.15);}
 
 .stack-10{display:grid; gap:10px;}
 .stack-12{display:grid; gap:12px;}


### PR DESCRIPTION
## Summary
- wire login, signup, and password reset modals to Supabase with accessible messaging
- guard app dashboard from unauthenticated access and redirect existing sessions
- add subtle button hover shadows and textured background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c197fb17488326adc4b883a5743ec6