### PR TITLE
Asegura wiring de auth y guard de sesión

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
           <input id="liPass" type="password" autocomplete="current-password">
         </div>
       </div>
-      <p id="liMsg" class="muted" role="status" aria-live="polite"></p>
+      <p id="msgLogin" class="muted" role="status" aria-live="polite"></p>
       <div class="row space-between">
         <button id="btnForgot" class="btn btn-soft" type="button">Olvidé mi contraseña</button>
         <div class="row">
@@ -64,15 +64,15 @@
       <h2 id="signupTitle">Crear cuenta</h2>
       <div class="stack-12">
         <div>
-          <label for="suEmail">Correo</label>
-          <input id="suEmail" type="email" autocomplete="email">
+          <label for="siEmail">Correo</label>
+          <input id="siEmail" type="email" autocomplete="email">
         </div>
         <div>
-          <label for="suPass">Contraseña</label>
-          <input id="suPass" type="password" autocomplete="new-password">
+          <label for="siPass">Contraseña</label>
+          <input id="siPass" type="password" autocomplete="new-password">
         </div>
       </div>
-      <p id="suMsg" class="muted" role="status" aria-live="polite"></p>
+      <p id="msgSignup" class="muted" role="status" aria-live="polite"></p>
       <div class="row end">
         <button id="btnCloseSignup" class="btn" type="button">Cancelar</button>
         <button id="btnDoSignup" class="btn btn-primary" type="button">Crear cuenta</button>


### PR DESCRIPTION
## Summary
- Estabiliza modales de acceso con IDs esperados y mensajes accesibles
- Añade wiring completo de Supabase para login, registro y reset con logs y redirección
- Implementa guard de sesión en `/app.html`

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1a0be1af48326ab5eba4943e7e9a4