### PR TITLE
Fix Supabase auth env handling and session guard

### DIFF
--- a/app.html
+++ b/app.html
@@ -128,6 +128,11 @@
     </section>
   </main>
 
+  <!-- ENV runtime (pública) -->
+  <script id="__env">
+    window.SUPABASE_URL = (window.SUPABASE_URL || 'https://nzzzeycpfdtvzphbupbf.supabase.co').trim();
+    window.SUPABASE_ANON_KEY = (window.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im56enpleWNwZmR0dnpwaGJ1cGJmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0NDA3MTIsImV4cCI6MjA3MzAxNjcxMn0.HoAjTwnWdtjueVALlX4-du7uF919QEMj8SS2CHP0N44').trim();
+  </script>
   <script src="https://unpkg.com/@supabase/supabase-js@2" defer></script>
   <script src="/app.js" defer></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -84,6 +84,11 @@
     <p class="muted">© <span id="year"></span> Prouti. Todos los derechos reservados.</p>
   </footer>
 
+  <!-- ENV runtime (pública) -->
+  <script id="__env">
+    window.SUPABASE_URL = (window.SUPABASE_URL || 'https://nzzzeycpfdtvzphbupbf.supabase.co').trim();
+    window.SUPABASE_ANON_KEY = (window.SUPABASE_ANON_KEY || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im56enpleWNwZmR0dnpwaGJ1cGJmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0NDA3MTIsImV4cCI6MjA3MzAxNjcxMn0.HoAjTwnWdtjueVALlX4-du7uF919QEMj8SS2CHP0N44').trim();
+  </script>
   <script src="https://unpkg.com/@supabase/supabase-js@2" defer></script>
   <script src="/app.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- Inject runtime Supabase URL and anon key in static HTML
- Initialize Supabase client once with strict validation and expose as `window.sb`
- Wire login/signup/reset flows to global client and guard app session on load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ab051f8483269141c22e8c3a11a7