### PR TITLE
refactor: unify Supabase client across pages

### DIFF
--- a/app.html
+++ b/app.html
@@ -129,6 +129,7 @@
   </main>
 
   <script src="https://unpkg.com/@supabase/supabase-js@2" defer></script>
+  <script src="/supabase-client.js" defer></script>
   <script src="/app.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
   </footer>
 
   <script src="https://unpkg.com/@supabase/supabase-js@2" defer></script>
+  <script src="/supabase-client.js" defer></script>
   <script src="/app.js" defer></script>
 </body>
 </html>

--- a/supabase-client.js
+++ b/supabase-client.js
@@ -1,0 +1,18 @@
+(function initSupabase(){
+  const URL = 'https://nzzzeycpfdtvzphbupbf.supabase.co';
+  const KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im56enpleWNwZmR0dnpwaGJ1cGJmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0NDA3MTIsImV4cCI6MjA3MzAxNjcxMn0.HoAjTwnWdtjueVALlX4-du7uF919QEMj8SS2CHP0N44';
+  if (window.sb) {
+    console.info('[Supabase] using existing client');
+    return;
+  }
+  if (!window.supabase) {
+    console.error('[Supabase] SDK no encontrado');
+    return;
+  }
+  try {
+    window.sb = window.supabase.createClient(URL, KEY);
+    console.info('[Supabase] client inicializado');
+  } catch (err) {
+    console.error('[Supabase] init error', err);
+  }
+})();


### PR DESCRIPTION
## Summary
- add global `supabase-client.js` to share a single Supabase client
- load Supabase SDK and client on both `index.html` and `app.html`
- refactor `app.js` to use `window.sb` and guard sessions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c238d023a08326a0925c8922a06a36