### PR TITLE
refactor: use env-based supabase client

### DIFF
--- a/app.html
+++ b/app.html
@@ -128,8 +128,6 @@
     </section>
   </main>
 
-  <script src="https://unpkg.com/@supabase/supabase-js@2" defer></script>
-  <script src="/supabase-client.js" defer></script>
-  <script src="/app.js" defer></script>
+  <script type="module" src="/app.js"></script>
 </body>
 </html>

--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+import supabase from './supabase-client.js';
+
 // Utilidades y helpers
 const $ = id => document.getElementById(id);
 const el = (sel, root=document) => root.querySelector(sel);
@@ -30,8 +32,6 @@ function closeModal(id){
 }
 const todayStr = () => new Date().toISOString().slice(0,10);
 
-// Supabase client se inicializa en supabase-client.js
-
 // SPA helpers
 const sections = ['hub','goals','meals','progress'];
 function show(id){ sections.forEach(s => $(s).classList.toggle('hide', s!==id)); }
@@ -49,7 +49,7 @@ $('#navToMeals')?.addEventListener('click', () => show('meals'));
 $('#ctaGoMeals')?.addEventListener('click', () => show('meals'));
 $('#navToProgress')?.addEventListener('click', () => show('progress'));
 $('#ctaGoProgress')?.addEventListener('click', () => show('progress'));
-$('#btnLogout')?.addEventListener('click', async()=>{ await window.sb.auth.signOut(); });
+$('#btnLogout')?.addEventListener('click', async()=>{ await supabase.auth.signOut(); });
 $('#btnSaveGoals')?.addEventListener('click', saveGoals);
 $('#btnAddMeal')?.addEventListener('click', addMeal);
 $('#mealsTbody')?.addEventListener('click',e=>{
@@ -78,7 +78,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
     if(!email || !password){ setLive('msgLogin','Ingresa correo y contraseña.'); return; }
     const btn=$('btnDoLogin'); btn.disabled=true; setLive('msgLogin','Ingresando…');
     try{
-      const { data, error } = await window.sb.auth.signInWithPassword({ email, password });
+      const { data, error } = await supabase.auth.signInWithPassword({ email, password });
       if(error){ console.error('[Login]',error); setLive('msgLogin', error.message); btn.disabled=false; return; }
       setLive('msgLogin','Sesión iniciada. Redirigiendo…');
       location.href='/app.html';
@@ -93,7 +93,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
     if(!email||!password){ setLive('msgSignup','Completa correo y contraseña.'); return; }
     const btn=$('btnDoSignup'); btn.disabled=true; setLive('msgSignup','Creando cuenta…');
     try{
-      const { data, error } = await window.sb.auth.signUp({ email, password });
+      const { data, error } = await supabase.auth.signUp({ email, password });
       if(error){ console.error('[Signup]',error); setLive('msgSignup', error.message||'No pudimos crear tu cuenta.'); btn.disabled=false; return; }
       setLive('msgSignup','Cuenta creada. Revisa tu correo para confirmar.');
       btn.disabled=false;
@@ -105,14 +105,14 @@ document.addEventListener('DOMContentLoaded', ()=>{
     const email=$('liEmail')?.value?.trim(); if(!email){ setLive('msgLogin','Ingresa tu correo.'); return; }
     const btn=$('btnForgot'); btn.disabled=true; setLive('msgLogin','Enviando enlace…');
     try{
-      const { error } = await window.sb.auth.resetPasswordForEmail(email, { redirectTo: location.origin+'/reset.html' });
+      const { error } = await supabase.auth.resetPasswordForEmail(email, { redirectTo: location.origin+'/reset.html' });
       if(error){ console.error('[Reset]',error); setLive('msgLogin', error.message||'No se pudo enviar el enlace.'); btn.disabled=false; return; }
       setLive('msgLogin','Te enviamos un enlace para restablecer tu contraseña.');
       btn.disabled=false;
     }catch(err){ console.error('[Reset unexpected]',err); setLive('msgLogin','Error inesperado.'); btn.disabled=false; }
   });
 
-  window.sb.auth.getSession().then(({ data:{ session } })=>{
+  supabase.auth.getSession().then(({ data:{ session } })=>{
     if(session && !$('#hub')) location.href='/app.html';
   });
 });
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
 document.addEventListener('DOMContentLoaded', async () => {
   if (!$('#hub')) return; // solo en app.html
   try{
-    const { data: { session } } = await window.sb.auth.getSession();
+    const { data: { session } } = await supabase.auth.getSession();
     if(!session){
       window.location.replace('/');
       return;
@@ -131,7 +131,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     await loadMealsToday();
     await loadCompliance7d();
     show('hub');
-    const { data:{ subscription } } = window.sb.auth.onAuthStateChange((_event, session)=>{
+    const { data:{ subscription } } = supabase.auth.onAuthStateChange((_event, session)=>{
       if(!session){
         sessionStorage.setItem('landingMsg','Tu sesión ha finalizado.');
         window.location.replace('/');
@@ -150,7 +150,7 @@ window.addEventListener('beforeunload',()=>{
 
 // Funciones de datos
 async function loadGoals(){
-  const { data } = await window.sb.from('goals').select('*').eq('user_id', user.id).maybeSingle();
+  const { data } = await supabase.from('goals').select('*').eq('user_id', user.id).maybeSingle();
   goals = data;
   if(data){
     $('#metaKcal').value = data.kcal_target || '';
@@ -173,7 +173,7 @@ async function saveGoals(){
     setLive('msgGoals','Ingresa valores válidos');
     return;
   }
-    const { error } = await window.sb.from('goals').upsert({
+    const { error } = await supabase.from('goals').upsert({
     user_id:user.id,
     kcal_target:kcal,
     protein_g_target:prot,
@@ -189,7 +189,7 @@ async function saveGoals(){
 async function loadMealsToday(reset=true){
   const body = $('#mealsTbody');
   if(reset){ body.innerHTML=''; mealPage=0; }
-  const { data, error, count } = await window.sb.from('meals')
+  const { data, error, count } = await supabase.from('meals')
     .select('id,food_name,kcal,protein_g,carbs_g,fat_g',{ count:'exact' })
     .eq('user_id', user.id).eq('eaten_at', todayStr())
     .order('id',{ascending:false})
@@ -250,7 +250,7 @@ async function loadMealsToday(reset=true){
   }
   if((mealPage+1)*10 < (count||0)) $('#btnMoreMeals').classList.remove('hide'); else $('#btnMoreMeals').classList.add('hide');
 
-  const { data:totals } = await window.sb.from('v_daily_totals').select('*').eq('user_id', user.id).eq('day', todayStr()).maybeSingle();
+  const { data:totals } = await supabase.from('v_daily_totals').select('*').eq('user_id', user.id).eq('day', todayStr()).maybeSingle();
   renderTodaySummary(totals);
   $('#statMeals').textContent = `${count||0} regs / ${fmt.kcal(totals?.kcal)}`;
   $('#statMeals').classList.remove('skeleton');
@@ -289,7 +289,7 @@ async function addMeal(){
   const kcalInput=Number($('#mealKcal').value);
   if(!name || qty<=0){ setLive('msgMeals','Datos inválidos'); return; }
   const kcal = kcalInput>0 ? kcalInput : prot*4 + carb*4 + fat*9;
-    const { error } = await window.sb.from('meals').insert({
+    const { error } = await supabase.from('meals').insert({
     user_id:user.id,
     eaten_at:todayStr(),
     food_name:name,
@@ -310,7 +310,7 @@ async function addMeal(){
 
 async function deleteMeal(id){
   if(!confirm('¿Eliminar comida?')) return;
-    await window.sb.from('meals').delete().eq('id', id);
+    await supabase.from('meals').delete().eq('id', id);
   await loadMealsToday();
   await loadCompliance7d();
 }
@@ -319,7 +319,7 @@ async function loadCompliance7d(){
   const fromDate = new Date();
   fromDate.setDate(fromDate.getDate()-6);
   const start = fromDate.toISOString().slice(0,10);
-  const { data } = await window.sb.from('v_daily_totals').select('day,kcal').eq('user_id', user.id).gte('day', start).lte('day', todayStr()).order('day');
+  const { data } = await supabase.from('v_daily_totals').select('day,kcal').eq('user_id', user.id).gte('day', start).lte('day', todayStr()).order('day');
   const gkcal = goals?.kcal_target;
   const points=[];
   if(gkcal && data){

--- a/index.html
+++ b/index.html
@@ -84,8 +84,6 @@
     <p class="muted">© <span id="year"></span> Prouti. Todos los derechos reservados.</p>
   </footer>
 
-  <script src="https://unpkg.com/@supabase/supabase-js@2" defer></script>
-  <script src="/supabase-client.js" defer></script>
-  <script src="/app.js" defer></script>
+  <script type="module" src="/app.js"></script>
 </body>
 </html>

--- a/supabase-client.js
+++ b/supabase-client.js
@@ -1,18 +1,8 @@
-(function initSupabase(){
-  const URL = 'https://nzzzeycpfdtvzphbupbf.supabase.co';
-  const KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im56enpleWNwZmR0dnpwaGJ1cGJmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0NDA3MTIsImV4cCI6MjA3MzAxNjcxMn0.HoAjTwnWdtjueVALlX4-du7uF919QEMj8SS2CHP0N44';
-  if (window.sb) {
-    console.info('[Supabase] using existing client');
-    return;
-  }
-  if (!window.supabase) {
-    console.error('[Supabase] SDK no encontrado');
-    return;
-  }
-  try {
-    window.sb = window.supabase.createClient(URL, KEY);
-    console.info('[Supabase] client inicializado');
-  } catch (err) {
-    console.error('[Supabase] init error', err);
-  }
-})();
+import { createClient } from '@supabase/supabase-js';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_ANON_KEY
+);
+
+export default supabase;


### PR DESCRIPTION
## Summary
- initialize Supabase client using environment variables and export it for reuse
- import the shared client in app logic and remove window-based references
- load application scripts as ES modules, removing inline Supabase scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c58c314ed0832686ea07c20de383af