### PR TITLE
use Supabase CDN ESM and external env

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-import supabase from './supabase-client.js';
+import { supabase } from './supabase-client.js';
 
 // Utilidades y helpers
 const $ = id => document.getElementById(id);

--- a/index.html
+++ b/index.html
@@ -85,8 +85,6 @@
     <p class="muted">© <span id="year"></span> Prouti. Todos los derechos reservados.</p>
   </footer>
 
-  <script defer src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  <script defer src="/supabase-client.js"></script>
-  <script defer src="/app.js"></script>
+  <script type="module" src="/app.js"></script>
 </body>
 </html>

--- a/supabase-client.js
+++ b/supabase-client.js
@@ -1,8 +1,7 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './supabase-env.js';
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_ANON_KEY
+export const supabase = createClient(
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY
 );
-
-export default supabase;

--- a/supabase-env.js
+++ b/supabase-env.js
@@ -1,0 +1,2 @@
+export const SUPABASE_URL = '';
+export const SUPABASE_ANON_KEY = '';


### PR DESCRIPTION
## Summary
- load `@supabase/supabase-js` from CDN ESM build
- move Supabase credentials into `supabase-env.js`
- export configured `supabase` instance and update consumers
- clean index scripts to use module loading

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c596a1d25883269eb7b3e8c570eec0