### PR TITLE
feat: delegate landing modal events

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ function setLive(id, msg){
   }
 }
 function openModal(id){
+  console.info('[openModal]', id);
   const m = $(id);
   if(m){
     m.classList.remove('hide');
@@ -24,6 +25,7 @@ function openModal(id){
   }
 }
 function closeModal(id){
+  console.info('[closeModal]', id);
   const m = $(id);
   if(m){
     m.classList.add('hide');
@@ -58,6 +60,23 @@ $('#mealsTbody')?.addEventListener('click',e=>{
 });
 $('#btnMoreMeals')?.addEventListener('click', ()=>{ mealPage++; loadMealsToday(false); });
 
+// Delegación de eventos para modales en landing
+document.addEventListener('click', e => {
+  const t = e.target;
+  if (t.closest('#btnOpenLogin')) {
+    openModal('loginModal');
+    return;
+  }
+  if (t.closest('#btnOpenSignup')) {
+    openModal('signupModal');
+    return;
+  }
+  const closeEl = t.closest('[data-close-modal]');
+  if (closeEl) {
+    closeModal(closeEl.dataset.closeModal);
+  }
+});
+
 // Landing: manejo de modales y auth
 document.addEventListener('DOMContentLoaded', ()=>{
   const msg = sessionStorage.getItem('landingMsg');
@@ -65,11 +84,6 @@ document.addEventListener('DOMContentLoaded', ()=>{
     setLive('accessMsg', msg);
     sessionStorage.removeItem('landingMsg');
   }
-  $('btnOpenLogin')?.addEventListener('click', () => openModal('loginModal'));
-  $('btnOpenSignup')?.addEventListener('click', () => openModal('signupModal'));
-  $('btnCloseLogin')?.addEventListener('click', () => closeModal('loginModal'));
-  $('btnCloseSignup')?.addEventListener('click', () => closeModal('signupModal'));
-
   $('btnDoLogin')?.addEventListener('click', onDoLogin);
   async function onDoLogin(e){
     e.preventDefault();

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
 
   <!-- Login Modal -->
   <div id="loginModal" class="modal hide" role="dialog" aria-modal="true" aria-labelledby="loginTitle">
-    <div class="modal-backdrop"></div>
+    <div class="modal-backdrop" data-close-modal="loginModal"></div>
     <div class="modal-card card">
       <h2 id="loginTitle">Iniciar sesión</h2>
       <div class="stack-12">
@@ -51,7 +51,7 @@
       <div class="row space-between">
         <button id="btnForgot" class="btn btn-soft" type="button">Olvidé mi contraseña</button>
         <div class="row">
-          <button id="btnCloseLogin" class="btn" type="button">Cancelar</button>
+        <button id="btnCloseLogin" class="btn" type="button" data-close-modal="loginModal">Cancelar</button>
           <button id="btnDoLogin" class="btn btn-primary" type="button">Entrar</button>
         </div>
       </div>
@@ -60,7 +60,7 @@
 
   <!-- Signup Modal -->
   <div id="signupModal" class="modal hide" role="dialog" aria-modal="true" aria-labelledby="signupTitle">
-    <div class="modal-backdrop"></div>
+    <div class="modal-backdrop" data-close-modal="signupModal"></div>
     <div class="modal-card card">
       <h2 id="signupTitle">Crear cuenta</h2>
       <div class="stack-12">
@@ -75,7 +75,7 @@
       </div>
       <p id="msgSignup" class="muted" role="status" aria-live="polite"></p>
       <div class="row end">
-        <button id="btnCloseSignup" class="btn" type="button">Cancelar</button>
+        <button id="btnCloseSignup" class="btn" type="button" data-close-modal="signupModal">Cancelar</button>
         <button id="btnDoSignup" class="btn btn-primary" type="button">Crear cuenta</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- delegate modal open/close buttons from one document click handler
- log modal actions and add data-close-modal attributes for closing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59f8318248326b05a9ad7a7b5c2fc