### PR TITLE
fix: bind landing modal buttons

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,25 +60,15 @@ $('#mealsTbody')?.addEventListener('click',e=>{
 });
 $('#btnMoreMeals')?.addEventListener('click', ()=>{ mealPage++; loadMealsToday(false); });
 
-// Delegación de eventos para modales en landing
-document.addEventListener('click', e => {
-  const t = e.target;
-  if (t.closest('#btnOpenLogin')) {
-    openModal('loginModal');
-    return;
-  }
-  if (t.closest('#btnOpenSignup')) {
-    openModal('signupModal');
-    return;
-  }
-  const closeEl = t.closest('[data-close-modal]');
-  if (closeEl) {
-    closeModal(closeEl.dataset.closeModal);
-  }
-});
-
 // Landing: manejo de modales y auth
 document.addEventListener('DOMContentLoaded', ()=>{
+  console.info('[landing] binding modal listeners');
+  $('#btnOpenLogin')?.addEventListener('click', () => openModal('loginModal'));
+  $('#btnOpenSignup')?.addEventListener('click', () => openModal('signupModal'));
+  document.addEventListener('click', e => {
+    const closeEl = e.target.closest('[data-close-modal]');
+    if (closeEl) closeModal(closeEl.dataset.closeModal);
+  });
   const msg = sessionStorage.getItem('landingMsg');
   if(msg){
     setLive('accessMsg', msg);


### PR DESCRIPTION
## Summary
- bind login and signup buttons after migrating to ESM
- delegate close button clicks for modals
- add console.info logs for debugging

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5a1d9a8288326b27512f5c6d1e31a