### PR TITLE
Fix: remove Vercel env dependency via runtime env.js fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 ## Configuración
 
-Copia `.env.example` a `.env` y rellena `SUPABASE_URL` y `SUPABASE_ANON_KEY` con los valores de tu proyecto de Supabase.
+La aplicación obtiene la configuración de Supabase en tiempo de ejecución desde [`env.js`](./env.js). Si deseas usar tus propias credenciales, edita ese archivo con la URL y anon key de tu proyecto de Supabase.

--- a/app.html
+++ b/app.html
@@ -128,6 +128,7 @@
     </section>
   </main>
 
+  <script src="/env.js"></script>
   <script type="module" src="/app.js"></script>
 </body>
 </html>

--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-import { supabase } from './supabase-client.js';
+import { sb as supabase } from './supabase-client.js';
 
 // Utilidades y helpers
 const $ = id => document.getElementById(id);

--- a/env.js
+++ b/env.js
@@ -1,0 +1,4 @@
+window.__ENV = {
+  SUPABASE_URL: "https://nzzzeycpfdtvzphbupbf.supabase.co",
+  SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im56enpleWNwZmR0dnpwaGJ1cGJmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc0NDA3MTIsImV4cCI6MjA3MzAxNjcxMn0.HoAjTwnWdtjueVALlX4-du7uF919QEMj8SS2CHP0N44"
+};

--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
     <p class="muted">© <span id="year"></span> Prouti. Todos los derechos reservados.</p>
   </footer>
 
+  <script src="/env.js"></script>
   <script type="module" src="/app.js"></script>
 </body>
 </html>

--- a/supabase-client.js
+++ b/supabase-client.js
@@ -1,10 +1,7 @@
 import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/+esm';
-import { SUPABASE_URL, SUPABASE_ANON_KEY } from './supabase-env.js';
 
-// Supabase singleton
-export const supabase = createClient(
-  SUPABASE_URL,
-  SUPABASE_ANON_KEY
-);
+const url = window.__ENV?.SUPABASE_URL || window.SUPABASE_URL || '';
+const key = window.__ENV?.SUPABASE_ANON_KEY || window.SUPABASE_ANON_KEY || '';
 
-export default supabase;
+export const sb = createClient(url, key);
+export default sb;

--- a/supabase-env.js
+++ b/supabase-env.js
@@ -1,2 +1,0 @@
-export const SUPABASE_URL = '';
-export const SUPABASE_ANON_KEY = '';

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,0 @@
-{
-  "env": {
-    "SUPABASE_URL": "@supabase-url",
-    "SUPABASE_ANON_KEY": "@supabase-anon-key"
-  }
-}


### PR DESCRIPTION
## Summary
- load supabase config from public env.js at runtime
- init client from window env instead of Vercel secrets
- remove Vercel env wiring

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e9b983608326aea362cccca58284